### PR TITLE
Do not validate empty string.

### DIFF
--- a/edtf_convert/edtf_to_temper.py
+++ b/edtf_convert/edtf_to_temper.py
@@ -18,7 +18,7 @@ DATES = re.compile(r'\d+')
 
 # Pattern to identify a TEMPER date. Pattern does not currently support
 # timezones.
-TEMPER = re.compile(r'^(?:(?:(?<![?])(?:bce|-)?\d{4,})[?]?~?(?:-|, (?=(?:bce|-)?\d{4,}))?)*$',
+TEMPER = re.compile(r'^(?:(?:(?<![?])(?:bce|-)?\d{4,})[?]?~?(?:-|, (?=(?:bce|-)?\d{4,}))?)+$',
                     re.I)
 
 # Dates with a season look like 2016-21.

--- a/tests/test_edtf_to_temper.py
+++ b/tests/test_edtf_to_temper.py
@@ -33,6 +33,7 @@ from edtf_convert import edtf_to_temper
     ('unknown/2006', '(:unav) unavailable'),
     ('2004-01-01/unknown', '20040101-'),
     ('[-0174..-0132]', '-0174--0132'),
+    ('', '(:unav) unavailable'),
 ])
 def test_edtf_to_temper(edtf_date, temper_date):
     assert edtf_to_temper.EDTFToTEMPER(edtf_date).temper == temper_date


### PR DESCRIPTION
@somexpert previously this was allowing `''` as a valid TEMPER date. This changes that.